### PR TITLE
Fix Test Reporting Workflows & Update readme

### DIFF
--- a/.github/workflows/ci-reports.yml
+++ b/.github/workflows/ci-reports.yml
@@ -1,4 +1,4 @@
-name: 'Test Reports'
+name: 'CI Reports'
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,9 @@ jobs:
         with:
           gradle-version: 7.3
           arguments: clean test build artifactoryPublish
-      - name: List Build Outputs
-        run: cd exposed-tests/build/test-results/test && ls -lart
       - name: Upload Test Artifacts
-        uses: actions/upload-artifact@v2  # upload test results
-        if: success() || failure()        # run this step even if previous step failed
+        uses: actions/upload-artifact@v2
+        if: success() || failure()
         with:
           name: Test Artifacts
           path: exposed-tests/build/test-results/*/*.xml

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,17 +24,9 @@ jobs:
         with:
           gradle-version: 7.3
           arguments: clean test build artifactoryPublish
-      - name: Upload Postgres Test Results
-        uses: dorny/test-reporter@v1.5.0
+      - name: Upload Test Artifacts
+        uses: actions/upload-artifact@v2
         if: success() || failure()
         with:
-          name: Postgres Test Results
-          path: exposed-tests/build/test-results/postgresTest/*.xml
-          reporter: java-junit
-      - name: Upload MySQL Test Results
-        uses: dorny/test-reporter@v1.5.0
-        if: success() || failure()
-        with:
-          name: MySQL Test Results
-          path: exposed-tests/build/test-results/mysql51Test/*.xml
-          reporter: java-junit
+          name: Test Artifacts
+          path: exposed-tests/build/test-results/*/*.xml

--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -1,7 +1,9 @@
 name: 'Test Reports'
 on:
   workflow_run:
-    workflows: ['CI']
+    workflows:
+      - 'CI'
+      - 'CI & CD'
     types:
       - completed
 jobs:
@@ -13,47 +15,47 @@ jobs:
         with:
           artifact: Test Artifacts
           name: Postgres Test Results
-          path: exposed-tests/build/test-results/postgresTest/*.xml
+          path: postgresTest/*.xml
           reporter: java-junit
       - name: Upload Postgres Test Results
         uses: dorny/test-reporter@v1.5.0
         with:
           artifact: Test Artifacts
           name: Postgres Test Results
-          path: exposed-tests/build/test-results/postgresTest/*.xml
+          path: postgresTest/*.xml
           reporter: java-junit
       - name: Upload Mysql Test Results
         uses: dorny/test-reporter@v1.5.0
         with:
           artifact: Test Artifacts
           name: Postgres Test Results
-          path: exposed-tests/build/test-results/mysql51Test/*.xml
+          path: mysql51Test/*.xml
           reporter: java-junit
       - name: Upload SQL lite Test Results
         uses: dorny/test-reporter@v1.5.0
         with:
           artifact: Test Artifacts
           name: SQL lite Test Results
-          path: exposed-tests/build/test-results/sqliteTest/*.xml
+          path: sqliteTest/*.xml
           reporter: java-junit
       - name: Upload Postgres NG Results
         uses: dorny/test-reporter@v1.5.0
         with:
           artifact: Test Artifacts
           name: Postgres NG Results
-          path: exposed-tests/build/test-results/postgresNGTest/*.xml
+          path: postgresNGTest/*.xml
           reporter: java-junit
       - name: Upload H2 V2 Test Results
         uses: dorny/test-reporter@v1.5.0
         with:
           artifact: Test Artifacts
           name: H2 V2 Test Results
-          path: exposed-tests/build/test-results/h2_v2Test/*.xml
+          path: h2_v2Test/*.xml
           reporter: java-junit
       - name: Upload H2 V1 Test Results
         uses: dorny/test-reporter@v1.5.0
         with:
           artifact: Test Artifacts
           name: H2 V1 Test Results
-          path: exposed-tests/build/test-results/h2_v1Test/*.xml
+          path: h2_v1Test/*.xml
           reporter: java-junit

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,10 +17,15 @@ Visit [the official Exposed page](https://github.com/JetBrains/Exposed) for an u
 
 ```kotlin
 val exposedVersion: String by project
+repositories {
+    maven("https://tmpasipanodya.jfrog.io/artifactory/releases")
+}
+
 dependencies {
-    implementation("io.taff.exposed:exposed-core:$exposedVersion")
-    implementation("io.taff.exposed:exposed-dao:$exposedVersion")
-    implementation("io.taff.exposed:exposed-jdbc:$exposedVersion")
+    implementation(platform("io.taff.exposed:exposed-bom:0.4.0"))
+    implementation("io.taff.exposed", "exposed-core")
+    implementation("io.taff.exposed", "exposed-dao")
+    implementation("io.taff.exposed", "exposed-jdbc")
 }
 ```
 

--- a/exposed-bom/README.md
+++ b/exposed-bom/README.md
@@ -15,9 +15,9 @@ Bill of Materials for all Exposed modules
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>org.jetbrains.exposed</groupId>
+            <groupId>io.taff.exposed</groupId>
             <artifactId>exposed-bom</artifactId>
-            <version>0.37.3</version>
+            <version>0.4.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -26,17 +26,17 @@ Bill of Materials for all Exposed modules
 
 <dependencies>
     <dependency>
-        <groupId>org.jetbrains.exposed</groupId>
+        <groupId>io.taff.exposed</groupId>
         <artifactId>exposed-core</artifactId>
         <scope>provided</scope>
     </dependency>
     <dependency>
-        <groupId>org.jetbrains.exposed</groupId>
+        <groupId>io.taff.exposed</groupId>
         <artifactId>exposed-dao</artifactId>
         <scope>provided</scope>
     </dependency>
     <dependency>
-        <groupId>org.jetbrains.exposed</groupId>
+        <groupId>io.taff.exposed</groupId>
         <artifactId>exposed-jdbc</artifactId>
         <scope>provided</scope>
     </dependency>
@@ -51,9 +51,9 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.exposed:exposed-bom:0.37.2"))
-    implementation("org.jetbrains.exposed", "exposed-core")
-    implementation("org.jetbrains.exposed", "exposed-dao")
-    implementation("org.jetbrains.exposed", "exposed-jdbc")
+    implementation(platform("io.taff.exposed:exposed-bom:0.4.0"))
+    implementation("io.taff.exposed", "exposed-core")
+    implementation("io.taff.exposed", "exposed-dao")
+    implementation("io.taff.exposed", "exposed-jdbc")
 }
 ```


### PR DESCRIPTION
- The test reporting workflow failed because it's path was configured incorrectly.
- `exposed-bom` README.md instructions incorrectly had `org.jetbrains.exposed` documented as this project's group id.