### PR TITLE
Bump org.jmailen.kotlinter from 3.4.4 to 3.4.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "1.5.10" apply true
     id("io.github.gradle-nexus.publish-plugin") apply true
-    id("org.jmailen.kotlinter") version "3.4.4"
+    id("org.jmailen.kotlinter") version "3.4.5"
 }
 
 allprojects {


### PR DESCRIPTION
Bumps org.jmailen.kotlinter from 3.4.4 to 3.4.5.

---
updated-dependencies:
- dependency-name: org.jmailen.kotlinter dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>